### PR TITLE
invalidate the proxy of the base state after immer function executes

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -175,10 +175,33 @@ describe("base", () => {
             s.aProp = undefined
         })
         expect(nextState).not.toBe(baseState)
-        expect(baseState.aProp).toBe('hi')
+        expect(baseState.aProp).toBe("hi")
         expect(nextState.aProp).toBe(undefined)
     })
 
+    it("should revoke the proxy of the baseState after immer function is executed", () => {
+        let proxy
+        const nextState = immer(baseState, s => {
+            proxy = s
+            s.aProp = "hello"
+        })
+        expect(nextState).not.toBe(baseState)
+        expect(baseState.aProp).toBe("hi")
+        expect(nextState.aProp).toBe("hello")
+
+        expect(() => {
+            proxy.aProp = "Hallo"
+        }).toThrowError(/^Cannot perform.*on a proxy that has been revoked/)
+        expect(() => {
+            const aProp = proxy.aProp
+        }).toThrowError(/^Cannot perform.*on a proxy that has been revoked/)          
+
+        expect(nextState).not.toBe(baseState)
+        expect(baseState.aProp).toBe("hi")
+        expect(nextState.aProp).toBe("hello")
+
+    })
+    
     afterEach(() => {
         expect(baseState).toBe(origBaseState)
         expect(baseState).toEqual(createBaseState())

--- a/immer.js
+++ b/immer.js
@@ -1,3 +1,9 @@
+/**
+ * @typedef {Object} RevocableProxy
+ * @property {any} proxy
+ * @property {Function} revoke
+ */
+
 // @ts-check
 
 const isProxySymbol = Symbol("immer-proxy")
@@ -13,9 +19,14 @@ const isProxySymbol = Symbol("immer-proxy")
  * @returns {any} a new state, or the base state if nothing was modified
  */
 function immer(baseState, thunk) {
-    // Maps baseState objects to proxies
-    const proxies = new Map()
+
+    /**
+     * Maps baseState objects to revocable proxies
+     * @type {Map<Object,RevocableProxy>}
+     */
+    const revocableProxies = new Map()
     // Maps baseState objects to their copies
+
     const copies = new Map()
 
     const objectTraps = {
@@ -60,15 +71,16 @@ function immer(baseState, thunk) {
         const copy = copies.get(base)
         return copy || base
     }
-
+    
     // creates a proxy for plain objects / arrays
     function createProxy(base) {
         if (isPlainObject(base) || Array.isArray(base)) {
             if (isProxy(base)) return base // avoid double wrapping
-            if (proxies.has(base)) return proxies.get(base)
-            const proxy = new Proxy(base, objectTraps)
-            proxies.set(base, proxy)
-            return proxy
+            if (revocableProxies.has(base)) return revocableProxies.get(base).proxy
+            //const proxy = new Proxy(base, objectTraps)
+            const revocableProxy = Proxy.revocable(base, objectTraps)
+            revocableProxies.set(base, revocableProxy)
+            return revocableProxy.proxy
         }
         return base
     }
@@ -76,7 +88,7 @@ function immer(baseState, thunk) {
     // checks if the given base object has modifications, either because it is modified, or
     // because one of it's children is
     function hasChanges(base) {
-        const proxy = proxies.get(base)
+        const proxy = revocableProxies.get(base)
         if (!proxy) return false // nobody did read this object
         if (copies.has(base)) return true // a copy was created, so there are changes
         // look deeper
@@ -117,8 +129,21 @@ function immer(baseState, thunk) {
     const rootClone = createProxy(baseState)
     // execute the thunk
     thunk(rootClone)
+    // revoke all proxies
+    revoke(revocableProxies)
     // and finalize the modified proxy
     return finalize(baseState)
+}
+
+/**
+ * Revoke all the proxies stored in the revocableProxies map
+ * 
+ * @param {Map<Object,RevocableProxy>} revocableProxies
+ */
+function revoke (revocableProxies){
+    for (var revocableProxy of revocableProxies.values()) {
+        revocableProxy.revoke()
+    }
 }
 
 function isPlainObject(value) {


### PR DESCRIPTION
1. Using a revocable proxy instead of a proxy, we invalidate the proxy when immer function executes
1. I used jsdoc @typedef, but I can create an internal typescript definition file and reference it in immer. js if needed

Fixes #10