### PR TITLE
Add index.d.ts in package.json `files` attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "homepage": "https://github.com/mweststrate/immer#readme",
   "files": [
-    "immer.js"
+    "immer.js",
+    "index.d.ts"
   ],
   "devDependencies": {
     "@types/jest": "^22.0.0",


### PR DESCRIPTION
This is needed in order to have the definition file included when immer is packaged

Fixes #18