### PR TITLE
Include es5.js in npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/mweststrate/immer#readme",
   "files": [
     "immer.js",
+    "es5.js",
     "index.d.ts"
   ],
   "devDependencies": {


### PR DESCRIPTION
es5.js is not included when installing immer 0.2.0 from npmjs :
```sh
ll node_modules/immer
total 76
drwxr-xr-x   2 nico users  4096  4 janv. 01:32 .
drwxr-xr-x 751 nico users 36864  4 janv. 01:33 ..
-rw-r--r--   1 nico users  1836  4 janv. 01:32 changelog.md
-rw-r--r--   1 nico users  7725  4 janv. 01:32 immer.js
-rw-r--r--   1 nico users   970  4 janv. 01:32 index.d.ts
-rw-r--r--   1 nico users  1074  4 janv. 01:32 LICENSE
-rw-r--r--   1 nico users  1261  4 janv. 01:32 package.json
-rw-r--r--   1 nico users  7346  4 janv. 01:32 readme.md
```