### PR TITLE
explicit return of setAutoFreeze

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,4 +18,4 @@ export default function<S = any>(
  * This comes with a performance impact, so it is recommended to disable this option in production.
  * It is by default enabled.
  */
-export function setAutoFreeze(autoFreeze: boolean)
+export function setAutoFreeze(autoFreeze: boolean): void;


### PR DESCRIPTION
Change the definition of `setAutoFreeze` to avoid typescript with `"noImplicitAny": true,` options to throw an Error.