### PR TITLE
Fixed finalizing array

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -506,6 +506,40 @@ function runBaseTest(name, useProxies, freeze) {
             })
         })
 
+        it("should not throw error", () => {
+            const base = {
+                arr: [
+                    {
+                        id: "100",
+                        arr: [{id: "1", no: 1}, {id: "2", no: 2}]
+                    },
+                    {id: "3", no: 3}
+                ]
+            }
+            const result = produce(base, draft => {
+                const base = draft.arr[0]
+                draft.arr = draft.arr.slice(0, 1)
+                const newArr = {
+                    id: "101",
+                    arr: [base, {id: "3"}]
+                }
+                draft.arr.splice(0, 1, newArr)
+                draft.arr[0].arr[1].no = 3
+            })
+            expect(result).toEqual({
+                arr: [{
+                    id: "101",
+                    arr: [
+                        {
+                            id: "100",
+                            arr: [{id: "1", no: 1}, {id: "2", no: 2}]
+                        },
+                        {id: "3", no: 3}
+                    ]
+                }]
+            })
+        })
+
         it("should handle dates correctly", () => {
             const data = {date: new Date()}
             const next = produce(data, draft => {

--- a/src/es5.js
+++ b/src/es5.js
@@ -156,11 +156,7 @@ export function finalizeArray(proxy, state) {
     const res = (state.copy = shallowCopy(proxy))
     const base = state.base
     each(res, (i, value) => {
-        if (value !== base[i]) {
-            res[i] = finalize(value)
-        } else {
-            res[i] = finalize(res[i])
-        }
+        res[i] = finalize(value)
     })
     return freeze(res)
 }

--- a/src/es5.js
+++ b/src/es5.js
@@ -156,7 +156,11 @@ export function finalizeArray(proxy, state) {
     const res = (state.copy = shallowCopy(proxy))
     const base = state.base
     each(res, (i, value) => {
-        if (value !== base[i]) res[i] = finalize(value)
+        if (value !== base[i]) {
+            res[i] = finalize(value)
+        } else {
+            res[i] = finalize(res[i])
+        }
     })
     return freeze(res)
 }

--- a/src/es5.js
+++ b/src/es5.js
@@ -154,7 +154,6 @@ export function finalizeObject(proxy, state) {
 
 export function finalizeArray(proxy, state) {
     const res = (state.copy = shallowCopy(proxy))
-    const base = state.base
     each(res, (i, value) => {
         res[i] = finalize(value)
     })

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -136,7 +136,6 @@ export function finalizeObject(state) {
 
 export function finalizeArray(state) {
     const copy = state.copy
-    const base = state.base
     each(copy, (i, value) => {
         copy[i] = finalize(value)
     })

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -138,7 +138,11 @@ export function finalizeArray(state) {
     const copy = state.copy
     const base = state.base
     each(copy, (i, value) => {
-        if (value !== base[i]) copy[i] = finalize(value)
+        if (value !== base[i]) {
+            copy[i] = finalize(value)
+        } else {
+            copy[i] = finalize(copy[i])
+        }
     })
     return freeze(copy)
 }

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -138,11 +138,7 @@ export function finalizeArray(state) {
     const copy = state.copy
     const base = state.base
     each(copy, (i, value) => {
-        if (value !== base[i]) {
-            copy[i] = finalize(value)
-        } else {
-            copy[i] = finalize(copy[i])
-        }
+        copy[i] = finalize(value)
     })
     return freeze(copy)
 }


### PR DESCRIPTION
I got error on this test case. (see the diff)
I could not figure out why this is caused.
It seems some copy of array element is a Proxy.
Therefore, I did finalizing copy on `finalizeArray` in any case.

I don't know the same thing is needed on `finalizeObject`.
Would you review my code please?

I'm very glad to meet such a wonderful library :)

**addition**

I found another case below:
```
const base = {
    arr: [{count: 1}, {count: 2}]
}
const result = produce(base, draft => {
    draft.arr = [
        draft.arr[1]
    ]
    draft.arr[0].count = 1
})
expect(result).toEqual({
    arr: [{count: 1}]
})
```
This also causes an error.
Shouldn't I use the draft object on new array or object....?