### PR TITLE
Fixed treating constructor on proxy

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -555,6 +555,19 @@ function runBaseTest(name, useProxies, freeze) {
             })
         })
 
+        it("should handle constructor correctly", () => {
+            const base = {
+                arr: new Array(),
+                obj: new Object()
+            }
+            const result = produce(base, draft => {
+                draft.arrConstructed = draft.arr.constructor(1)
+                draft.objConstructed = draft.obj.constructor(1)
+            })
+            expect(result.arrConstructed).toEqual(new Array().constructor(1))
+            expect(result.objConstructed).toEqual(new Object().constructor(1))
+        })
+
         it("should handle dates correctly", () => {
             const data = {date: new Date()}
             const next = produce(data, draft => {

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -65,7 +65,8 @@ function get(state, prop) {
             return (state.copy[prop] = createProxy(state, value))
         return value
     } else {
-        if (prop in state.proxies) return state.proxies[prop]
+        if (prop !== "constructor" && prop in state.proxies)
+            return state.proxies[prop]
         const value = state.base[prop]
         if (!isProxy(value) && isProxyable(value))
             return (state.proxies[prop] = createProxy(state, value))


### PR DESCRIPTION
I fixed a problem on using constructor for proxy of an array.
It is caused because `'constructor' in state.proxies` always become `true`.