### PR TITLE
Fix TypeScript declarations to support currying and immutable state

### DIFF
--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -1,3 +1,7 @@
+type Mutable<T extends {[x: string]: any}, K extends string> = {
+	[P in K]: T[P];
+}
+
 /**
  * Immer takes a state, and runs a function against it.
  * That function can freely mutate the state, as it will create copies-on-write.
@@ -12,7 +16,7 @@
  */
 export default function<S = any>(
     currentState: S,
-    recipe: (this: S, draftState: S) => void
+    recipe?: (this: S, draftState: Mutable<S, keyof S>) => void
 ): S
 // curried invocations
 export default function<S = any, A = any, B = any, C = any>(


### PR DESCRIPTION
The TypeScript declarations prevent modying the produced draft if it was produced from an object that has a readonly interface:

```ts
interface IState {
  readonly foo: boolean;
}

const state: IState = {
  foo: false
};

produce(state, draft => {
  draft.foo = true; // Error: Cannot assign to 'foo' because it is a constant or a read-only property.
});
```

Also calling `produce` with only one argument is not allowed, so currying is impossible:

```ts
const mapper = produce((draft, index) => { // Error: Invalid number of arguments, expected 2.
  ...
});
```

This PR solves both of these cases.