### PR TITLE
Replace Object.assign in common, since it's not supported in IE

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -56,9 +56,13 @@ export function freeze(value) {
 
 export function shallowCopy(value) {
     if (Array.isArray(value)) return value.slice()
-    if (value.__proto__ === undefined)
-        return Object.assign(Object.create(null), value)
-    return Object.assign({}, value)
+    const target = value.__proto__ === undefined ? Object.create(null) : {}
+    for (let key in value) {
+        if (has(value, key)) {
+            target[key] = value[key]
+        }
+    }
+    return target
 }
 
 export function each(value, cb) {


### PR DESCRIPTION
Object.assign() is not available in IE11. In environments without polyfills this library crashes on IE. This PR replaces it with a for-in loop.