### PR TITLE
Fix #148: default returned value

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -905,6 +905,22 @@ function runBaseTest(name, useProxies, freeze) {
             expect(next).toEqual({dots: base.availableStartingDots})
         })
 
+        it("should return an unmodified primitive baseState (#148)", () => {
+            const baseState = "some string"
+            const nextState = produce(baseState, () => {
+                /* no modification  */
+            })
+            expect(nextState).toBe(baseState)
+        })
+
+        it("should return an unmodified null baseState (#148)", () => {
+            const baseState = null
+            const nextState = produce(baseState, () => {
+                /* no modification  */
+            })
+            expect(nextState).toBe(baseState)
+        })
+
         it("immer should have no dependencies", () => {
             expect(require("../package.json").dependencies).toEqual(undefined)
         })

--- a/src/immer.js
+++ b/src/immer.js
@@ -46,9 +46,12 @@ export default function produce(baseState, producer) {
         if (typeof producer !== "function") throw new Error("if first argument is not a function, the second argument to produce should be a function")
     }
 
-    // if state is a primitive, don't bother proxying at all and just return whatever the producer returns on that value
-    if (typeof baseState !== "object" || baseState === null)
-        return producer(baseState)
+    // if state is a primitive, don't bother proxying at all
+    if (typeof baseState !== "object" || baseState === null) {
+        const returnValue = producer(baseState)
+        return returnValue === undefined ? baseState : returnValue
+    }
+
     if (!isProxyable(baseState))
         throw new Error(
             `the first argument to an immer producer should be a primitive, plain object or array, got ${typeof baseState}: "${baseState}"`


### PR DESCRIPTION
This PR adds a spec for #148. and fixes it. 

When the `baseState` is a primitive value or `null`, immer takes a shortcut and doesn't proxy. But it must still check if the producer returns `undefined`, and if yes, return the `baseState`. 