### PR TITLE
Fix: Base test uses "if(...)" instead of it(...)"

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -48,15 +48,15 @@ function runBaseTest(name, useProxies, freeze) {
 
         it("should preserve type", () => {
             const nextState = produce(baseState, s => {
-                expect(Array.isArray(s)).toBe(true)
-                expect(s.protoType).toBe(Object)
+                expect(Object.getPrototypeOf(s)).toBe(Object.prototype)
+                expect(Array.isArray(s.anArray)).toBe(true)
                 s.anArray.push(3)
                 s.aProp = "hello world"
-                expect(Array.isArray(s)).toBe(true)
-                expect(s.protoType).toBe(Object)
+                expect(Object.getPrototypeOf(s)).toBe(Object.prototype)
+                expect(Array.isArray(s.anArray)).toBe(true)
             })
-            expect(Array.isArray(nextState)).toBe(true)
-            expect(nextState.protoType).toBe(Object)
+            expect(Object.getPrototypeOf(nextState)).toBe(Object.prototype)
+            expect(Array.isArray(nextState.anArray)).toBe(true)
         })
 
         it("deep change bubbles up", () => {

--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -46,31 +46,29 @@ function runBaseTest(name, useProxies, freeze) {
             expect(nextState.nested).toBe(baseState.nested)
         })
 
-        if (
-            ("should preserve type",
-            () => {
-                const nextState = produce(baseState, s => {
-                    expect(Array.isArray(s)).toBe(true)
-                    expect(s.protoType).toBe(Object)
-                    s.anArray.push(3)
-                    s.aProp = "hello world"
-                    expect(Array.isArray(s)).toBe(true)
-                    expect(s.protoType).toBe(Object)
-                })
-                expect(Array.isArray(nextState)).toBe(true)
-                expect(nextState.protoType).toBe(Object)
+        it("should preserve type", () => {
+            const nextState = produce(baseState, s => {
+                expect(Array.isArray(s)).toBe(true)
+                expect(s.protoType).toBe(Object)
+                s.anArray.push(3)
+                s.aProp = "hello world"
+                expect(Array.isArray(s)).toBe(true)
+                expect(s.protoType).toBe(Object)
             })
-        )
-            it("deep change bubbles up", () => {
-                const nextState = produce(baseState, s => {
-                    s.anObject.nested.yummie = false
-                })
-                expect(nextState).not.toBe(baseState)
-                expect(nextState.anObject).not.toBe(baseState.anObject)
-                expect(baseState.anObject.nested.yummie).toBe(true)
-                expect(nextState.anObject.nested.yummie).toBe(false)
-                expect(nextState.anArray).toBe(baseState.anArray)
+            expect(Array.isArray(nextState)).toBe(true)
+            expect(nextState.protoType).toBe(Object)
+        })
+
+        it("deep change bubbles up", () => {
+            const nextState = produce(baseState, s => {
+                s.anObject.nested.yummie = false
             })
+            expect(nextState).not.toBe(baseState)
+            expect(nextState.anObject).not.toBe(baseState.anObject)
+            expect(baseState.anObject.nested.yummie).toBe(true)
+            expect(nextState.anObject.nested.yummie).toBe(false)
+            expect(nextState.anArray).toBe(baseState.anArray)
+        })
 
         it("can add props", () => {
             const nextState = produce(baseState, s => {


### PR DESCRIPTION
There is a test that doesn't run because of a typo: "if(...)" instead of it(...)". This hides other issues in the test.

This PR fixes the typo and also the actual test.
