### PR TITLE
Fix TypeScript example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -304,7 +304,7 @@ const state: State = {
   x: 0;
 };
 
-const newState = produce<State>(draft => {
+const newState = produce<State>(state, draft => {
   // `x` can be modified here
   draft.x++;
 });


### PR DESCRIPTION
Of course after #161 was merged I realized that my README example didn't actually do anything. This just makes sure that the original state is passed as the first parameter. Previously `newState` would have been a function instead of the new state object.