### PR TITLE
handle nested ReadonlyArray<T> better when using in TS project

### DIFF
--- a/__tests__/flow/ts.ts
+++ b/__tests__/flow/ts.ts
@@ -96,3 +96,23 @@ produce([1], draftState => {
         const c: number = a[0];
     }
 })
+
+type ObjectWithArray = {
+    items: Array<number>
+}
+
+function updateArray(oldItem: ObjectWithArray, newItems: Array<number>) {
+    return produce(oldItem, draftState => {
+        draftState.items = newItems
+    })
+}
+
+type ObjectWithReadonlyArray = {
+    items: ReadonlyArray<number>
+}
+
+function updateReadonlyArray(oldItem: ObjectWithReadonlyArray, newItems: ReadonlyArray<number>) {
+    return produce(oldItem, draftState => {
+        draftState.items = newItems
+    })
+}

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -4,9 +4,13 @@ export type DraftObject<T> = {
   -readonly [P in keyof T]: Draft<T[P]>;
 };
 export interface DraftArray<T> extends Array<Draft<T>> { }
+
+interface DraftReadonlyArray<T> extends ReadonlyArray<Draft<T>> { }
+type DraftArrayish<T> = DraftArray<T> | DraftReadonlyArray<T>
+
 export type Draft<T> =
   T extends any[] ? DraftArray<T[number]> :
-  T extends ReadonlyArray<any> ? DraftArray<T[number]> :
+  T extends ReadonlyArray<any> ? DraftArrayish<T[number]> :
   T extends object ? DraftObject<T> :
   T;
 


### PR DESCRIPTION
I was experimenting with `immer` and found myself stuck on how arrays are represented in a TS project.

The example is basically this:

```ts
type ObjectWithReadonlyArray = {
    items: ReadonlyArray<number>
}

function updateReadonlyArray(oldItem: ObjectWithReadonlyArray, newItems: ReadonlyArray<number>) {
    return produce(oldItem, draftState => {
        draftState.items = newItems
    })
}
```

Unfortunately this errors, because `immer` maps both `Array<T>` and `ReadonlyArray<T>` to `DraftArray<T>` which extends Array<T>, and `ReadonlyArray<T>` only has a subset of the `Array<T>` API.

```
Type 'ReadonlyArray<number>' is not assignable to type 'DraftArray<number>'.
  Property 'push' is missing in type 'ReadonlyArray<number>'.
```

I added in some new TS examples to illustrate this, as well as fix the bug in the type declarations.

I think this doesn't require changes to the internals of `immer`, but let me know if there's anything else I can do here.