### PR TITLE
fix: deleting props from object which is in the array should save pat…

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -509,7 +509,7 @@ function runBaseTest(name, useProxies, freeze, useListener) {
                     expect(1 in draft).toBe(false)
                     expect("0" in draft).toBe(true)
                     expect("1" in draft).toBe(false)
-                    expect(length in draft).toBe(true)
+                    expect("length" in draft).toBe(true)
                     expect(
                         Reflect.ownKeys(draft).filter(
                             x => typeof x === "string"

--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -263,3 +263,18 @@ describe("simple delete", () => {
         ]
     )
 })
+
+describe("delete props from object which is in the array", () => {
+    runPatchTest(
+        [1, 2, {m: 1111}],
+        d => {
+            delete d[2].m
+        },
+        [
+            {
+                op: "remove",
+                path: [2, "m"]
+            }
+        ]
+    )
+})

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
       "^.+\\.jsx?$": "babel-jest",
       "^.+\\.tsx?$": "ts-jest"
     },
+    "testEnvironment": "node",
     "testRegex": "/__tests__/[^/]*[jt]sx?$",
     "globals": {
       "ts-jest": {

--- a/src/es5.js
+++ b/src/es5.js
@@ -128,33 +128,17 @@ function markChangesRecursively(object) {
     const state = object[PROXY_STATE]
     if (!state) return
     const {proxy, base} = state
-    if (Array.isArray(object)) {
-        if (hasArrayChanges(state)) {
-            markChanged(state)
-            state.assigned.length = true
-            if (proxy.length < base.length)
-                for (let i = proxy.length; i < base.length; i++)
-                    state.assigned[i] = false
-            else
-                for (let i = base.length; i < proxy.length; i++)
-                    state.assigned[i] = true
-            each(proxy, (index, child) => {
-                if (!state.assigned[index]) markChangesRecursively(child)
-            })
-        }
-    } else {
-        const {added, removed} = diffKeys(base, proxy)
-        if (added.length > 0 || removed.length > 0) markChanged(state)
-        each(added, (_, key) => {
-            state.assigned[key] = true
-        })
-        each(removed, (_, key) => {
-            state.assigned[key] = false
-        })
-        each(proxy, (key, child) => {
-            if (!state.assigned[key]) markChangesRecursively(child)
-        })
-    }
+    const {added, removed} = diffKeys(base, proxy)
+    if (added.length > 0 || removed.length > 0) markChanged(state)
+    each(added, (_, key) => {
+        state.assigned[key] = true
+    })
+    each(removed, (_, key) => {
+        state.assigned[key] = false
+    })
+    each(proxy, (key, child) => {
+        if (!state.assigned[key]) markChangesRecursively(child)
+    })
 }
 
 function diffKeys(from, to) {


### PR DESCRIPTION
I've found another question, see the code sample below.

```
   let base = [1,2, {name:"jim"}];
   let changes = []

   let fork = produce(
       base,
       draft => {
           delete draft[2].name;
       },
       (patches, inversePatches) => {
           changes.push(...patches)
       }
   )
   console.log(changes) //[]   deleting props from object should save the patches
```