### PR TITLE
Add an original function

### DIFF
--- a/__tests__/flow/flow.js.flow
+++ b/__tests__/flow/flow.js.flow
@@ -97,16 +97,22 @@ produce({x: 3}, [])
 
 {
     produce({x: 3}, draftState => {
-        original(draftState).x
-        // $ExpectError
-        original(draftState).y
+        let a = original(draftState)
+        if (a) {
+            a.x
+            // $ExpectError
+            a.y
+        }
     })
 }
 
 {
     produce([1], draftState => {
-        const a: number = original(draftState)[0];
-        // $ExpectError
-        const b: string = original(draftState)[0];
+        const a = original(draftState);
+        if (a) {
+            const b: number = a[0];
+            // $ExpectError
+            const c: string = a[0];
+        }
     })
 }

--- a/__tests__/flow/flow.js.flow
+++ b/__tests__/flow/flow.js.flow
@@ -1,5 +1,5 @@
 // @flow
-import produce, {setAutoFreeze, setUseProxies, produce as produce2, applyPatches, Patch} from "../../src/immer"
+import produce, {setAutoFreeze, setUseProxies, produce as produce2, applyPatches, Patch, original} from "../../src/immer"
 
 setAutoFreeze(true)
 setUseProxies(true)
@@ -93,4 +93,20 @@ produce({x: 3}, [])
         p = patches
     })
     applyPatches({}, p)
+}
+
+{
+    produce({x: 3}, draftState => {
+        original(draftState).x
+        // $ExpectError
+        original(draftState).y
+    })
+}
+
+{
+    produce([1], draftState => {
+        const a: number = original(draftState)[0];
+        // $ExpectError
+        const b: string = original(draftState)[0];
+    })
 }

--- a/__tests__/flow/ts.ts
+++ b/__tests__/flow/ts.ts
@@ -78,14 +78,21 @@ produce({x: 3}, [])
             : state
 }
 
-produce({x: 3}, draftState => {
-    original(draftState).x
-    // $ExpectError
-    original(draftState).y
+produce({x: 3, z: {}}, draftState => {
+    const a = draftState;
+
+    if (a) {
+        a.x
+        // $ExpectError
+        a.y
+    }
 })
 
 produce([1], draftState => {
-    // $ExpectError
-    const a: string = original(draftState)[0];
-    const b: number = original(draftState)[0];
+    const a = original(draftState);
+    if (a) {
+        // $ExpectError
+        const b: string = a[0];
+        const c: number = a[0];
+    }
 })

--- a/__tests__/flow/ts.ts
+++ b/__tests__/flow/ts.ts
@@ -1,4 +1,4 @@
-import produce, {setAutoFreeze, setUseProxies} from "../../src/immer"
+import produce, {setAutoFreeze, setUseProxies, original} from "../../src/immer"
 
 setAutoFreeze(true)
 setUseProxies(true)
@@ -77,3 +77,15 @@ produce({x: 3}, [])
             ? produce<any, any>(handlers[type])(state, payload)
             : state
 }
+
+produce({x: 3}, draftState => {
+    original(draftState).x
+    // $ExpectError
+    original(draftState).y
+})
+
+produce([1], draftState => {
+    // $ExpectError
+    const a: string = original(draftState)[0];
+    const b: number = original(draftState)[0];
+})

--- a/__tests__/original.js
+++ b/__tests__/original.js
@@ -1,0 +1,22 @@
+"use strict"
+import produce, {original} from "../src/immer"
+
+describe("original", () => {
+    const baseState = {
+        a: [],
+        b: {}
+    }
+
+    it("should return the original from the proxy", () => {
+        const nextState = produce(baseState, draftState => {
+            expect(original(draftState)).toBe(baseState)
+            expect(original(draftState.a)).toBe(baseState.a)
+            expect(original(draftState.b)).toBe(baseState.b)
+        })
+    })
+
+    it("should return the same object from an object that is not proxied", () => {
+        const a = []
+        expect(original(a)).toBe(a)
+    })
+})

--- a/__tests__/original.js
+++ b/__tests__/original.js
@@ -1,5 +1,5 @@
 "use strict"
-import produce, {original} from "../src/immer"
+import produce, {original, setUseProxies} from "../src/immer"
 
 describe("original", () => {
     const baseState = {
@@ -7,16 +7,43 @@ describe("original", () => {
         b: {}
     }
 
-    it("should return the original from the proxy", () => {
-        const nextState = produce(baseState, draftState => {
+    it("should return the original from the draft", () => {
+        setUseProxies(true)
+
+        produce(baseState, draftState => {
+            expect(original(draftState)).toBe(baseState)
+            expect(original(draftState.a)).toBe(baseState.a)
+            expect(original(draftState.b)).toBe(baseState.b)
+        })
+
+        setUseProxies(false)
+
+        produce(baseState, draftState => {
             expect(original(draftState)).toBe(baseState)
             expect(original(draftState.a)).toBe(baseState.a)
             expect(original(draftState.b)).toBe(baseState.b)
         })
     })
 
-    it("should return the same object from an object that is not proxied", () => {
-        const a = []
-        expect(original(a)).toBe(a)
+    it("should return the original from the proxy", () => {
+        produce(baseState, draftState => {
+            expect(original(draftState)).toBe(baseState)
+            expect(original(draftState.a)).toBe(baseState.a)
+            expect(original(draftState.b)).toBe(baseState.b)
+        })
+    })
+
+    it("should return undefined for new values on the draft", () => {
+        produce(baseState, draftState => {
+            draftState.c = {}
+            draftState.d = 3
+            expect(original(draftState.c)).toBeUndefined()
+            expect(original(draftState.d)).toBeUndefined()
+        })
+    })
+
+    it("should return undefined for an object that is not proxied", () => {
+        expect(original({})).toBeUndefined()
+        expect(original(3)).toBeUndefined()
     })
 })

--- a/readme.md
+++ b/readme.md
@@ -351,6 +351,17 @@ const userReducer = produce((draft, action) => {
 })
 ```
 
+## Extracting the original object from a proxied instance
+
+Immer exposes a named export `original` that will get the original object from the proxied instance inside `produce`. A good example of when this can be useful is when searching for nodes in a tree-like state using strict equality.
+
+```js
+const baseState = { users: [{ name: "Richie" }] };
+const nextState = produce(baseState, draftState => {
+    original(draftState.users) // is === baseState.users
+})
+```
+
 ## Using `this`
 
 The recipe will be always invoked with the `draft` as `this` context.

--- a/readme.md
+++ b/readme.md
@@ -353,7 +353,7 @@ const userReducer = produce((draft, action) => {
 
 ## Extracting the original object from a proxied instance
 
-Immer exposes a named export `original` that will get the original object from the proxied instance inside `produce`. A good example of when this can be useful is when searching for nodes in a tree-like state using strict equality.
+Immer exposes a named export `original` that will get the original object from the proxied instance inside `produce` (or return `undefined` for unproxied values). A good example of when this can be useful is when searching for nodes in a tree-like state using strict equality.
 
 ```js
 const baseState = { users: [{ name: "Richie" }] };

--- a/src/common.js
+++ b/src/common.js
@@ -56,6 +56,10 @@ export function freeze(value) {
     return value
 }
 
+export function original(value) {
+    return value && value[PROXY_STATE] ? value[PROXY_STATE].base : value
+}
+
 const assign =
     Object.assign ||
     function assign(target, value) {

--- a/src/common.js
+++ b/src/common.js
@@ -57,7 +57,10 @@ export function freeze(value) {
 }
 
 export function original(value) {
-    return value && value[PROXY_STATE] ? value[PROXY_STATE].base : value
+    if (value && value[PROXY_STATE]) {
+        return value[PROXY_STATE].base
+    }
+    // otherwise return undefined
 }
 
 const assign =

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -111,4 +111,4 @@ export function setUseProxies(useProxies: boolean): void
 
 export function applyPatches<S>(state: S, patches: Patch[]): S
 
-export function original<T>(value: T): T
+export function original<T>(value: T): T | void

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -110,3 +110,5 @@ export function setAutoFreeze(autoFreeze: boolean): void
 export function setUseProxies(useProxies: boolean): void
 
 export function applyPatches<S>(state: S, patches: Patch[]): S
+
+export function original<T>(value: T): T

--- a/src/immer.js
+++ b/src/immer.js
@@ -1,4 +1,4 @@
-export {setAutoFreeze, setUseProxies} from "./common"
+export {setAutoFreeze, setUseProxies, original} from "./common"
 
 import {applyPatches as applyPatchesImpl} from "./patches"
 import {isProxyable, getUseProxies} from "./common"

--- a/src/immer.js.flow
+++ b/src/immer.js.flow
@@ -85,4 +85,4 @@ declare export function setUseProxies(useProxies: boolean): void
 
 declare export function applyPatches<S>(state: S, patches: Patch[]): S
 
-declare export function original<S>(value: S): S
+declare export function original<S>(value: S): ?S

--- a/src/immer.js.flow
+++ b/src/immer.js.flow
@@ -84,3 +84,5 @@ declare export function setAutoFreeze(autoFreeze: boolean): void
 declare export function setUseProxies(useProxies: boolean): void
 
 declare export function applyPatches<S>(state: S, patches: Patch[]): S
+
+declare export function original<S>(value: S): S


### PR DESCRIPTION
This addresses #153 and exposes an `original` function, useful for `===` comparing a proxy with an original object. The docs / tests should explain most of the implementation!