### PR TITLE
Adapt freeze test to changed exception message in Node v10.10.0

### DIFF
--- a/__tests__/frozen.js
+++ b/__tests__/frozen.js
@@ -40,7 +40,9 @@ function runTests(name, useProxies) {
 
             expect(() => {
                 next.array.shift()
-            }).toThrow(/Cannot add\/remove sealed array elements/)
+            }).toThrow(
+                /Cannot add\/remove sealed array elements|Cannot assign to read only property '0' of object '\[object Array\]'/
+            )
         })
 
         it("can handle already frozen trees", () => {


### PR DESCRIPTION
When using Node.js v10.10.0, 2 tests fail for me in `frozen.js`. The reason is that the exception message for modifying a frozen object changed.

This PR changes the test such that it works on older and on the current Node.js version.
