### PR TITLE
Upgrade prettier and enable prettier on TypeScript code

### DIFF
--- a/__tests__/flow/ts.ts
+++ b/__tests__/flow/ts.ts
@@ -79,7 +79,7 @@ produce({x: 3}, [])
 }
 
 produce({x: 3, z: {}}, draftState => {
-    const a = draftState;
+    const a = draftState
 
     if (a) {
         a.x
@@ -89,10 +89,10 @@ produce({x: 3, z: {}}, draftState => {
 })
 
 produce([1], draftState => {
-    const a = original(draftState);
+    const a = original(draftState)
     if (a) {
         // $ExpectError
-        const b: string = a[0];
-        const c: number = a[0];
+        const b: string = a[0]
+        const c: number = a[0]
     }
 })

--- a/__tests__/types.ts
+++ b/__tests__/types.ts
@@ -1,96 +1,99 @@
-import produce, { produce as produce2, applyPatches, Patch} from '../src/immer';
+import produce, {produce as produce2, applyPatches, Patch} from "../src/immer"
 
 interface State {
-  readonly num: number;
-  readonly foo?: string;
-  bar: string;
-  readonly baz: {
-    readonly x: number;
-    readonly y: number;
-  };
-  readonly arr: ReadonlyArray<{ readonly value: string }>;
-  readonly arr2: { readonly value: string }[];
+    readonly num: number
+    readonly foo?: string
+    bar: string
+    readonly baz: {
+        readonly x: number
+        readonly y: number
+    }
+    readonly arr: ReadonlyArray<{readonly value: string}>
+    readonly arr2: {readonly value: string}[]
 }
 
 const state: State = {
-  num: 0,
-  bar: 'foo',
-  baz: {
-    x: 1,
-    y: 2,
-  },
-  arr: [{ value: 'asdf' }],
-  arr2: [{ value: 'asdf' }],
-};
+    num: 0,
+    bar: "foo",
+    baz: {
+        x: 1,
+        y: 2
+    },
+    arr: [{value: "asdf"}],
+    arr2: [{value: "asdf"}]
+}
 
 const expectedState: State = {
-  num: 1,
-  foo: 'bar',
-  bar: 'foo',
-  baz: {
-    x: 2,
-    y: 3,
-  },
-  arr: [{ value: 'foo' }, { value: 'asf' }],
-  arr2: [{ value: 'foo' }, { value: 'asf' }],
-};
+    num: 1,
+    foo: "bar",
+    bar: "foo",
+    baz: {
+        x: 2,
+        y: 3
+    },
+    arr: [{value: "foo"}, {value: "asf"}],
+    arr2: [{value: "foo"}, {value: "asf"}]
+}
 
-it('can update readonly state via standard api', () => {
-  const newState = produce<State>(state, draft => {
-    draft.num++;
-    draft.foo = 'bar';
-    draft.bar = 'foo';
-    draft.baz.x++;
-    draft.baz.y++;
-    draft.arr[0].value = 'foo';
-    draft.arr.push({ value: 'asf' });
-    draft.arr2[0].value = 'foo';
-    draft.arr2.push({ value: 'asf' });
-  });
-  expect(newState).not.toBe(state);
-  expect(newState).toEqual(expectedState);
-});
-
-it('can update readonly state via curried api', () => {
-  const newState = produce<State>(draft => {
-    draft.num++;
-    draft.foo = 'bar';
-    draft.bar = 'foo';
-    draft.baz.x++;
-    draft.baz.y++;
-    draft.arr[0].value = 'foo';
-    draft.arr.push({ value: 'asf' });
-    draft.arr2[0].value = 'foo';
-    draft.arr2.push({ value: 'asf' });
-  })(state);
-  expect(newState).not.toBe(state);
-  expect(newState).toEqual(expectedState);
-});
-
-
-it('can update use the non-default export', () => {
-  const newState = produce2<State>(draft => {
-    draft.num++;
-    draft.foo = 'bar';
-    draft.bar = 'foo';
-    draft.baz.x++;
-    draft.baz.y++;
-    draft.arr[0].value = 'foo';
-    draft.arr.push({ value: 'asf' });
-    draft.arr2[0].value = 'foo';
-    draft.arr2.push({ value: 'asf' });
-  })(state);
-  expect(newState).not.toBe(state);
-  expect(newState).toEqual(expectedState);
-});
-
-it('can apply patches', () => {
-    let patches: Patch[]
-    produce({ x: 3 }, d=> {
-      d.x++
-    }, (p) => {
-        patches = p
+it("can update readonly state via standard api", () => {
+    const newState = produce<State>(state, draft => {
+        draft.num++
+        draft.foo = "bar"
+        draft.bar = "foo"
+        draft.baz.x++
+        draft.baz.y++
+        draft.arr[0].value = "foo"
+        draft.arr.push({value: "asf"})
+        draft.arr2[0].value = "foo"
+        draft.arr2.push({value: "asf"})
     })
+    expect(newState).not.toBe(state)
+    expect(newState).toEqual(expectedState)
+})
+
+it("can update readonly state via curried api", () => {
+    const newState = produce<State>(draft => {
+        draft.num++
+        draft.foo = "bar"
+        draft.bar = "foo"
+        draft.baz.x++
+        draft.baz.y++
+        draft.arr[0].value = "foo"
+        draft.arr.push({value: "asf"})
+        draft.arr2[0].value = "foo"
+        draft.arr2.push({value: "asf"})
+    })(state)
+    expect(newState).not.toBe(state)
+    expect(newState).toEqual(expectedState)
+})
+
+it("can update use the non-default export", () => {
+    const newState = produce2<State>(draft => {
+        draft.num++
+        draft.foo = "bar"
+        draft.bar = "foo"
+        draft.baz.x++
+        draft.baz.y++
+        draft.arr[0].value = "foo"
+        draft.arr.push({value: "asf"})
+        draft.arr2[0].value = "foo"
+        draft.arr2.push({value: "asf"})
+    })(state)
+    expect(newState).not.toBe(state)
+    expect(newState).toEqual(expectedState)
+})
+
+it("can apply patches", () => {
+    let patches: Patch[]
+    produce(
+        {x: 3},
+        d => {
+            d.x++
+        },
+        p => {
+            patches = p
+        }
+    )
 
     expect(applyPatches({}, patches)).toEqual({x: 4})
 })

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:flow": "yarn-or-npm flow check",
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "build": "rimraf dist/ && cross-env NODE_ENV=production rollup -c && cpx \"src/immer.{d.ts,js.flow}\" dist",
-    "prettier": "prettier \"*/**/*.js\" --ignore-path ./.prettierignore --write",
+    "prettier": "prettier \"*/**/*.js\" \"*/**/*.ts\" --ignore-path ./.prettierignore --write",
     "precommit": "lint-staged",
     "prepublish": "yarn-or-npm run build",
     "release": "np --no-cleanup"
@@ -76,6 +76,10 @@
   },
   "lint-staged": {
     "*.js": [
+      "prettier --write",
+      "git add"
+    ],
+    "*.ts": [
       "prettier --write",
       "git add"
     ]

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -1,18 +1,16 @@
 // Mapped type to remove readonly modifiers from state
 // Based on https://github.com/Microsoft/TypeScript/blob/d4dc67aab233f5a8834dff16531baf99b16fea78/tests/cases/conformance/types/conditional/conditionalTypes1.ts#L120-L129
-export type DraftObject<T> = {
-  -readonly [P in keyof T]: Draft<T[P]>;
-};
-export interface DraftArray<T> extends Array<Draft<T>> { }
-export type Draft<T> =
-  T extends any[] ? DraftArray<T[number]> :
-  T extends ReadonlyArray<any> ? DraftArray<T[number]> :
-  T extends object ? DraftObject<T> :
-  T;
+export type DraftObject<T> = {-readonly [P in keyof T]: Draft<T[P]>}
+export interface DraftArray<T> extends Array<Draft<T>> {}
+export type Draft<T> = T extends any[]
+    ? DraftArray<T[number]>
+    : T extends ReadonlyArray<any>
+        ? DraftArray<T[number]>
+        : T extends object ? DraftObject<T> : T
 
 export interface Patch {
-    op: "replace" | "remove" | "add",
-    path: (string|number)[]
+    op: "replace" | "remove" | "add"
+    path: (string | number)[]
     value?: any
 }
 
@@ -56,22 +54,32 @@ export interface IProduce {
     ): (currentState: S | undefined, a: A, b: B) => S
     // 3 additional arguments of types A, B and C
     <S = any, A = any, B = any, C = any>(
-        recipe: (this: Draft<S>, draftState: Draft<S>, a: A, b: B, c: C) => void | S,
+        recipe: (
+            this: Draft<S>,
+            draftState: Draft<S>,
+            a: A,
+            b: B,
+            c: C
+        ) => void | S,
         initialState: S
     ): (currentState: S | undefined, a: A, b: B, c: C) => S
     // any number of additional arguments, but with loss of type safety
     // this may be alleviated if "variadic kinds" makes it into Typescript:
     // https://github.com/Microsoft/TypeScript/issues/5453
     <S = any>(
-        recipe: (this: Draft<S>, draftState: Draft<S>, ...extraArgs: any[]) => void | S,
+        recipe: (
+            this: Draft<S>,
+            draftState: Draft<S>,
+            ...extraArgs: any[]
+        ) => void | S,
         initialState: S
     ): (currentState: S | undefined, ...extraArgs: any[]) => S
 
     // curried invocations without default initial state
     // 0 additional arguments
-    <S = any>(
-        recipe: (this: Draft<S>, draftState: Draft<S>) => void | S
-    ): (currentState: S) => S
+    <S = any>(recipe: (this: Draft<S>, draftState: Draft<S>) => void | S): (
+        currentState: S
+    ) => S
     // 1 additional argument of type A
     <S = any, A = any>(
         recipe: (this: Draft<S>, draftState: Draft<S>, a: A) => void | S
@@ -82,13 +90,23 @@ export interface IProduce {
     ): (currentState: S, a: A, b: B) => S
     // 3 additional arguments of types A, B and C
     <S = any, A = any, B = any, C = any>(
-        recipe: (this: Draft<S>, draftState: Draft<S>, a: A, b: B, c: C) => void | S
+        recipe: (
+            this: Draft<S>,
+            draftState: Draft<S>,
+            a: A,
+            b: B,
+            c: C
+        ) => void | S
     ): (currentState: S, a: A, b: B, c: C) => S
     // any number of additional arguments, but with loss of type safety
     // this may be alleviated if "variadic kinds" makes it into Typescript:
     // https://github.com/Microsoft/TypeScript/issues/5453
     <S = any>(
-        recipe: (this: Draft<S>, draftState: Draft<S>, ...extraArgs: any[]) => void | S
+        recipe: (
+            this: Draft<S>,
+            draftState: Draft<S>,
+            ...extraArgs: any[]
+        ) => void | S
     ): (currentState: S, ...extraArgs: any[]) => S
 }
 

--- a/src/patches.js
+++ b/src/patches.js
@@ -83,7 +83,9 @@ function generateObjectPatches(
         const value = resultValue[key]
         const op = !assignedValue
             ? "remove"
-            : key in baseValue ? "replace" : "add"
+            : key in baseValue
+                ? "replace"
+                : "add"
         if (origValue === baseValue && op === "replace") return
         const path = basepath.concat(key)
         patches.push(op === "remove" ? {op, path} : {op, path, value})
@@ -91,8 +93,8 @@ function generateObjectPatches(
             op === "add"
                 ? {op: "remove", path}
                 : op === "remove"
-                  ? {op: "add", path, value: origValue}
-                  : {op: "replace", path, value: origValue}
+                    ? {op: "add", path, value: origValue}
+                    : {op: "replace", path, value: origValue}
         )
     })
 }

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -114,7 +114,9 @@ function deleteProperty(state, prop) {
 function getOwnPropertyDescriptor(state, prop) {
     const owner = state.modified
         ? state.copy
-        : has(state.proxies, prop) ? state.proxies : state.base
+        : has(state.proxies, prop)
+            ? state.proxies
+            : state.base
     const descriptor = Reflect.getOwnPropertyDescriptor(owner, prop)
     if (descriptor && !(Array.isArray(owner) && prop === "length"))
         descriptor.configurable = true

--- a/yarn.lock
+++ b/yarn.lock
@@ -3931,8 +3931,8 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
 prettier@^1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.2.tgz#96bc2132f7a32338e6078aeb29727178c6335827"
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
 
 pretty-format@^21.2.1:
   version "21.2.1"


### PR DESCRIPTION
Later versions of Prettier support TypeScript.

This PR upgrades Prettier to the latest version and enables it on TypeScript code.