### PR TITLE
fix(produce): avoid throwing on unproxyable objects

### DIFF
--- a/__tests__/curry.js
+++ b/__tests__/curry.js
@@ -10,9 +10,6 @@ function runTests(name, useProxies) {
 
         it("should check arguments", () => {
             expect(() => produce()).toThrow(/produce expects 1 to 3 arguments/)
-            expect(() => produce(new Buffer(""), () => {})).toThrow(
-                /the first argument to an immer producer should be a primitive, plain object or array/
-            )
             expect(() => produce({}, () => {}, [])).toThrow(
                 /third argument of a producer/
             )

--- a/src/immer.js
+++ b/src/immer.js
@@ -49,18 +49,14 @@ export function produce(baseState, producer, patchListener) {
         if (patchListener !== undefined && typeof patchListener !== "function") throw new Error("the third argument of a producer should not be set or a function")
     }
 
-    // if state is a primitive, don't bother proxying at all
-    if (typeof baseState !== "object" || baseState === null) {
+    // avoid proxying anything except plain objects and arrays
+    if (!isProxyable(baseState)) {
         const returnValue = producer(baseState)
         return returnValue === undefined
             ? baseState
             : normalizeResult(returnValue)
     }
 
-    if (!isProxyable(baseState))
-        throw new Error(
-            `the first argument to an immer producer should be a primitive, plain object or array, got ${typeof baseState}: "${baseState}"`
-        )
     return normalizeResult(
         getUseProxies()
             ? produceProxy(baseState, producer, patchListener)


### PR DESCRIPTION
Fixes #233 

I'm thinking this is a breaking change, since someone may be relying on an error being thrown in some weird situation.