### PR TITLE
simplify curried producer impl

### DIFF
--- a/src/immer.js
+++ b/src/immer.js
@@ -28,18 +28,10 @@ export function produce(baseState, producer, patchListener) {
         const initialState = producer
         const recipe = baseState
 
-        return function() {
-            const args = arguments
-
-            const currentState =
-                args[0] === undefined && initialState !== undefined
-                    ? initialState
-                    : args[0]
-
-            return produce(currentState, draft => {
-                args[0] = draft // blegh!
-                return recipe.apply(draft, args)
-            })
+        return function(currentState = initialState, ...args) {
+            return produce(currentState, draft =>
+                recipe.call(draft, draft, ...args)
+            )
         }
     }
 


### PR DESCRIPTION
Babel spits out the following:
```js
return function () {
    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
        args[_key - 1] = arguments[_key];
    }

    var currentState = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialState;

    return produce(currentState, function (draft) {
        return recipe.call.apply(recipe, [draft, draft].concat(args));
    });
};
```

*edit:* I haven't run the perf tests yet.

WDYT?