### PR TITLE
fix(produce): never curry when 2nd argument is a function

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -1275,6 +1275,15 @@ function runBaseTest(name, useProxies, freeze, useListener) {
             })
         })
 
+        it("allows a function as the base state", () => {
+            let fn = () => {}
+            expect(
+                produce(fn, draft => {
+                    expect(fn).toBe(draft)
+                })
+            ).toBe(fn)
+        })
+
         it("cannot return and produce undefined!", () => {
             const base = 3
             expect(produce(base, () => 4)).toBe(4)

--- a/__tests__/curry.js
+++ b/__tests__/curry.js
@@ -20,9 +20,6 @@ function runTests(name, useProxies) {
             expect(() => produce({})).toThrow(
                 /if first argument is not a function, the second argument to produce should be a function/
             )
-            expect(() => produce(() => {}, () => {})).toThrow(
-                /if first argument is a function .* the second argument to produce cannot be a function/
-            )
         })
 
         it("should support currying", () => {

--- a/src/immer.js
+++ b/src/immer.js
@@ -21,10 +21,7 @@ export function produce(baseState, producer, patchListener) {
     if (arguments.length < 1 || arguments.length > 3) throw new Error("produce expects 1 to 3 arguments, got " + arguments.length)
 
     // curried invocation
-    if (typeof baseState === "function") {
-        // prettier-ignore
-        if (typeof producer === "function") throw new Error("if first argument is a function (curried invocation), the second argument to produce cannot be a function")
-
+    if (typeof baseState === "function" && typeof producer !== "function") {
         const initialState = producer
         const recipe = baseState
 


### PR DESCRIPTION
Currently, the first 2 arguments of `produce` cannot both be a function. Otherwise, an error is thrown.

Instead of throwing an error, the `produce(baseState, recipe)` code path should be taken, which would let users use functions as a base state. This goes really well with #236, because it lets us guarantee to callers that _any value_ can be used as the base state of a `produce` call.

You _cannot_ use a function as the `initialState` of a `produce(recipe, initialState)` call (also known as: a curried producer).