### PR TITLE
ci: use yarn cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 env:
   - NODE_ENV=TEST
 cache:
+  yarn: true
   directories:
     - "node_modules"
 script: yarn coveralls && yarn test:flow


### PR DESCRIPTION
Using the Yarn cache can speed up the builds significantly.