### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
+  - "6"
   - "8"
+  - "10"
+  - "node"
 env:
   - NODE_ENV=TEST
 cache:


### PR DESCRIPTION
Currently Node.js 6, 8 and 10 are active LTS branches and 11 is current stable.

We should test on all of these.

See https://github.com/nodejs/Release/blob/master/README.md