### PR TITLE
[TS] Allow extraArgs for curried producer with initial state

### DIFF
--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -80,10 +80,14 @@ export interface IProduce {
     ): void extends Result ? State : Result
 
     /** Curried producer with an initial state */
-    <State, Result = any>(
-        recipe: (this: Draft<State>, draft: Draft<State>) => void | Result,
+    <State, Result = any, Args extends any[] = any[]>(
+        recipe: (
+            this: Draft<State>,
+            draft: Draft<State>,
+            ...extraArgs: Args
+        ) => void | Result,
         defaultBase: State
-    ): (base: State | undefined) => void extends Result ? State : Result
+    ): (base: State | undefined, ...extraArgs: Args) => void extends Result ? State : Result
 
     /** Curried producer with no initial state */
     <State, Result = any, Args extends any[] = any[]>(


### PR DESCRIPTION
After upgrading to TypeScript 3.2.2, I started getting errors when using immer for reducers with initial state:

![image](https://user-images.githubusercontent.com/594564/50150292-c6dda600-02bd-11e9-8539-8cb077e1f8ba.png)

It worked if I used the curried producer without initial state, but not with initial state. So I tried adding `extraArgs` to the curried producer with initial state, and it started working again.