### PR TITLE
feat: limited class support

### DIFF
--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -292,8 +292,7 @@ describe("same value replacement - 2", () => {
             d.x = 4
             d.x = a
         },
-        // immer does not detect this is not an actual change
-        [{op: "replace", path: ["x"], value: {y: 3}}]
+        []
     )
 })
 
@@ -314,8 +313,7 @@ describe("same value replacement - 4", () => {
             d.x = 4
             d.x = 3
         },
-        // immer does not detect this is not an actual change
-        [{op: "replace", path: ["x"], value: 3}]
+        []
     )
 })
 

--- a/__tests__/polyfills.js
+++ b/__tests__/polyfills.js
@@ -1,0 +1,70 @@
+const {assign} = Object
+const {ownKeys} = Reflect
+const SymbolConstructor = Symbol
+
+Symbol = undefined
+Object.assign = undefined
+Reflect.ownKeys = undefined
+
+jest.resetModules()
+const common = require("../src/common")
+
+// Reset the globals to avoid unintended effects.
+Symbol = SymbolConstructor
+Object.assign = assign
+Reflect.ownKeys = ownKeys
+
+describe("Symbol", () => {
+    test("NOTHING", () => {
+        const value = common.NOTHING
+        expect(value).toBeTruthy()
+        expect(typeof value).toBe("object")
+    })
+    test("DRAFTABLE", () => {
+        const value = common.DRAFTABLE
+        expect(typeof value).toBe("string")
+    })
+    test("DRAFT_STATE", () => {
+        const value = common.DRAFT_STATE
+        expect(typeof value).toBe("string")
+    })
+})
+
+describe("Object.assign", () => {
+    const {assign} = common
+
+    it("only copies enumerable keys", () => {
+        const src = {a: 1}
+        Object.defineProperty(src, "b", {value: 1})
+        const dest = {}
+        assign(dest, src)
+        expect(dest.a).toBe(1)
+        expect(dest.b).toBeUndefined()
+    })
+
+    it("only copies own properties", () => {
+        const src = Object.create({a: 1})
+        src.b = 1
+        const dest = {}
+        assign(dest, src)
+        expect(dest.a).toBeUndefined()
+        expect(dest.b).toBe(1)
+    })
+})
+
+describe("Reflect.ownKeys", () => {
+    const {ownKeys} = common
+
+    // Symbol keys are always last.
+    it("includes symbol keys", () => {
+        const s = SymbolConstructor()
+        const obj = {[s]: 1, b: 1}
+        expect(ownKeys(obj)).toEqual(["b", s])
+    })
+
+    it("includes non-enumerable keys", () => {
+        const obj = {a: 1}
+        Object.defineProperty(obj, "b", {value: 1})
+        expect(ownKeys(obj)).toEqual(["a", "b"])
+    })
+})

--- a/__tests__/produce.ts
+++ b/__tests__/produce.ts
@@ -197,7 +197,8 @@ it("does not enforce immutability at the type level", () => {
 })
 
 it("can produce nothing", () => {
-    let val: undefined = produce({}, s => nothing)
+    let result = produce({}, _ => nothing)
+    exactType(result, undefined)
 })
 
 it("works with `void` hack", () => {

--- a/src/common.js
+++ b/src/common.js
@@ -80,14 +80,6 @@ export function each(value, cb) {
     if (Array.isArray(value)) {
         for (let i = 0; i < value.length; i++) cb(i, value[i], value)
     } else {
-        for (let key in value) cb(key, value[key], value)
-    }
-}
-
-export function eachOwn(value, cb) {
-    if (Array.isArray(value)) {
-        for (let i = 0; i < value.length; i++) cb(i, value[i], value)
-    } else {
         ownKeys(value).forEach(key => cb(key, value[key], value))
     }
 }

--- a/src/common.js
+++ b/src/common.js
@@ -42,7 +42,7 @@ export const assign =
     }
 
 export const ownKeys =
-    typeof Reflect !== "undefined"
+    typeof Reflect !== "undefined" && Reflect.ownKeys
         ? Reflect.ownKeys
         : obj =>
               Object.getOwnPropertyNames(obj).concat(

--- a/src/es5.js
+++ b/src/es5.js
@@ -131,7 +131,7 @@ function assertUnrevoked(state) {
     if (state.revoked === true)
         throw new Error(
             "Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? " +
-                JSON.stringify(state.copy || state.base)
+                JSON.stringify(source(state))
         )
 }
 

--- a/src/es5.js
+++ b/src/es5.js
@@ -7,10 +7,9 @@ import {
     is,
     isDraft,
     isDraftable,
+    isEnumerable,
     shallowCopy,
-    DRAFT_STATE,
-    eachOwn,
-    isEnumerable
+    DRAFT_STATE
 } from "./common"
 
 const descriptors = {}
@@ -32,7 +31,7 @@ export function willFinalize(result, baseDraft, needPatches) {
 export function createDraft(base, parent) {
     const isArray = Array.isArray(base)
     const draft = clonePotentialDraft(base)
-    eachOwn(draft, prop => {
+    each(draft, prop => {
         proxyProperty(draft, prop, isArray || isEnumerable(base, prop))
     })
 

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -154,16 +154,22 @@ export function setUseProxies(useProxies: boolean): void
  */
 export function applyPatches<S>(base: S, patches: Patch[]): S
 
+/** Get the underlying object that is represented by the given draft */
 export function original<T>(value: T): T | void
 
+/** For detecting an Immer draft */
 export function isDraft(value: any): boolean
 
 export class Immer {
     constructor(config: {
         useProxies?: boolean
         autoFreeze?: boolean
-        onAssign?: (state: ImmerState, prop: keyof any, value: any) => void
-        onDelete?: (state: ImmerState, prop: keyof any) => void
+        onAssign?: (
+            state: ImmerState,
+            prop: string | number,
+            value: unknown
+        ) => void
+        onDelete?: (state: ImmerState, prop: string | number) => void
         onCopy?: (state: ImmerState) => void
     })
     /**
@@ -213,5 +219,5 @@ export interface ImmerState<T = any> {
     parent?: ImmerState
     base: T
     copy: T
-    assigned: {[prop: string]: boolean}
+    assigned: {[prop: string]: boolean; [index: number]: boolean}
 }

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -123,6 +123,16 @@ declare class Nothing {
 export const nothing: Nothing
 
 /**
+ * To let Immer treat your class instances as plain immutable objects
+ * (albeit with a custom prototype), you must define either an instance property
+ * or a static property on each of your custom classes.
+ *
+ * Otherwise, your class instance will never be drafted, which means it won't be
+ * safe to mutate in a produce callback.
+ */
+export const immerable: unique symbol
+
+/**
  * Pass true to automatically freeze all copies created by Immer.
  *
  * By default, auto-freezing is disabled in production.

--- a/src/immer.js
+++ b/src/immer.js
@@ -168,7 +168,11 @@ export class Immer {
 
         const {onAssign} = this
         const finalizeProperty = (prop, value, parent) => {
-            // Only `root` can be a draft in here.
+            if (value === parent) {
+                throw Error("Immer forbids circular references")
+            }
+
+            // The only possible draft (in the scope of a `finalizeTree` call) is the `root` object.
             const inDraft = !!state && parent === root
 
             if (isDraft(value)) {

--- a/src/immer.js
+++ b/src/immer.js
@@ -56,11 +56,6 @@ export class Immer {
             result = recipe(base)
             if (result === undefined) return base
         }
-        // See #100, don't nest producers
-        else if (isDraft(base)) {
-            result = recipe.call(base, base)
-            if (result === undefined) return base
-        }
         // The given value must be proxied.
         else {
             this.scopes.push([])

--- a/src/immer.js
+++ b/src/immer.js
@@ -8,11 +8,10 @@ import {
     is,
     isDraft,
     isDraftable,
+    isEnumerable,
     shallowCopy,
     DRAFT_STATE,
-    NOTHING,
-    isEnumerable,
-    eachOwn
+    NOTHING
 } from "./common"
 
 function verifyMinified() {}
@@ -144,7 +143,7 @@ export class Immer {
                     }
                 } else {
                     const {base, copy} = state
-                    eachOwn(base, prop => {
+                    each(base, prop => {
                         if (!has(copy, prop)) this.onDelete(state, prop)
                     })
                 }
@@ -208,7 +207,7 @@ export class Immer {
             }
             // Search new objects for unfinalized drafts. Frozen objects should never contain drafts.
             else if (isDraftable(value) && !Object.isFrozen(value)) {
-                eachOwn(value, finalizeProperty)
+                each(value, finalizeProperty)
             }
 
             if (inDraft && onAssign) {
@@ -216,7 +215,7 @@ export class Immer {
             }
         }
 
-        eachOwn(root, finalizeProperty)
+        each(root, finalizeProperty)
         return root
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,11 @@ export const setUseProxies = value => immer.setUseProxies(value)
  */
 export const applyPatches = produce(applyPatchesImpl)
 
-export {original, isDraft, NOTHING as nothing} from "./common"
+export {
+    original,
+    isDraft,
+    NOTHING as nothing,
+    DRAFTABLE as immerable
+} from "./common"
 
 export {Immer}

--- a/src/patches.js
+++ b/src/patches.js
@@ -58,7 +58,7 @@ function generateObjectPatches(state, basePath, patches, inversePatches) {
         const origValue = base[key]
         const value = copy[key]
         const op = !assignedValue ? "remove" : key in base ? "replace" : "add"
-        if (origValue === base && op === "replace") return
+        if (origValue === value && op === "replace") return
         const path = basePath.concat(key)
         patches.push(op === "remove" ? {op, path} : {op, path, value})
         inversePatches.push(

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -65,12 +65,14 @@ const objectTraps = {
     set,
     deleteProperty,
     getOwnPropertyDescriptor,
-    defineProperty,
+    defineProperty() {
+        throw new Error("Object.defineProperty() cannot be used on an Immer draft") // prettier-ignore
+    },
     getPrototypeOf(target) {
         return Object.getPrototypeOf(target.base)
     },
     setPrototypeOf() {
-        throw new Error("Immer does not support `setPrototypeOf()`.")
+        throw new Error("Object.setPrototypeOf() cannot be used on an Immer draft") // prettier-ignore
     }
 }
 
@@ -82,18 +84,15 @@ each(objectTraps, (key, fn) => {
     }
 })
 arrayTraps.deleteProperty = function(state, prop) {
-    if (isNaN(parseInt(prop)))
-        throw new Error(
-            "Immer does not support deleting properties from arrays: " + prop
-        )
+    if (isNaN(parseInt(prop))) {
+        throw new Error("Immer only supports deleting array indices") // prettier-ignore
+    }
     return objectTraps.deleteProperty.call(this, state[0], prop)
 }
 arrayTraps.set = function(state, prop, value) {
-    if (prop !== "length" && isNaN(parseInt(prop)))
-        throw new Error(
-            "Immer does not support setting non-numeric properties on arrays: " +
-                prop
-        )
+    if (prop !== "length" && isNaN(parseInt(prop))) {
+        throw new Error("Immer only supports setting array indices and the 'length' property") // prettier-ignore
+    }
     return objectTraps.set.call(this, state[0], prop, value)
 }
 
@@ -160,12 +159,6 @@ function getOwnPropertyDescriptor(state, prop) {
     if (descriptor && !(Array.isArray(owner) && prop === "length"))
         descriptor.configurable = true
     return descriptor
-}
-
-function defineProperty() {
-    throw new Error(
-        "Immer does not support defining properties on draft objects."
-    )
 }
 
 function markChanged(state) {

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -66,6 +66,9 @@ const objectTraps = {
     deleteProperty,
     getOwnPropertyDescriptor,
     defineProperty,
+    getPrototypeOf(target) {
+        return Object.getPrototypeOf(target.base)
+    },
     setPrototypeOf() {
         throw new Error("Immer does not support `setPrototypeOf()`.")
     }

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -150,15 +150,13 @@ function deleteProperty(state, prop) {
 }
 
 function getOwnPropertyDescriptor(state, prop) {
-    const owner = state.modified
-        ? state.copy
-        : has(state.drafts, prop)
-        ? state.drafts
-        : state.base
-    const descriptor = Reflect.getOwnPropertyDescriptor(owner, prop)
-    if (descriptor && !(Array.isArray(owner) && prop === "length"))
-        descriptor.configurable = true
-    return descriptor
+    const owner = source(state)
+    const desc = Reflect.getOwnPropertyDescriptor(owner, prop)
+    if (desc) {
+        desc.writable = true
+        desc.configurable = !Array.isArray(owner) || prop !== "length"
+    }
+    return desc
 }
 
 function markChanged(state) {


### PR DESCRIPTION
When a class instance has the new `immerable` symbol in its own properties, its prototype, or on its constructor, the class instance can be drafted.

When drafted, class instances are basically plain objects, just with a different prototype. No magic here.

The main commit: https://github.com/mweststrate/immer/commit/be4898274f4da505849b4dda1abcd9e8bd035a4b

## Other changes

- Allow symbols as property names in drafts

- Add non-enumerable property support to drafts

- Improved error messages

- Fixed issue where ES5 drafts were not being marked as `finalizing` before being shallow cloned, which resulted in unnecessary draft creation