### PR TITLE
Async recipes

### DIFF
--- a/__tests__/__snapshots__/manual.js.snap
+++ b/__tests__/__snapshots__/manual.js.snap
@@ -8,6 +8,10 @@ exports[`manual - es5 should check arguments 2`] = `"First argument to createDra
 
 exports[`manual - es5 should check arguments 3`] = `"First argument to finishDraft should be an object from createDraft."`;
 
+exports[`manual - es5 should not finish drafts from produce 1`] = `"The draft provided was not created using \`createDraft\`"`;
+
+exports[`manual - es5 should not finish twice 1`] = `"The draft provided was has already been finished"`;
+
 exports[`manual - es5 should support patches drafts 1`] = `
 Array [
   Array [
@@ -53,6 +57,10 @@ exports[`manual - proxy should check arguments 1`] = `"First argument to createD
 exports[`manual - proxy should check arguments 2`] = `"First argument to createDraft should be a plain object, an array, or an immerable object."`;
 
 exports[`manual - proxy should check arguments 3`] = `"First argument to finishDraft should be an object from createDraft."`;
+
+exports[`manual - proxy should not finish drafts from produce 1`] = `"The draft provided was not created using \`createDraft\`"`;
+
+exports[`manual - proxy should not finish twice 1`] = `"The draft provided was has already been finished"`;
 
 exports[`manual - proxy should support patches drafts 1`] = `
 Array [

--- a/__tests__/__snapshots__/manual.js.snap
+++ b/__tests__/__snapshots__/manual.js.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`manual - es5 cannot modify after finish 1`] = `"Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":2}"`;
+
+exports[`manual - es5 should check arguments 1`] = `"First argument to createDraft should be a plain object, an array, or an immerable object."`;
+
+exports[`manual - es5 should check arguments 2`] = `"First argument to createDraft should be a plain object, an array, or an immerable object."`;
+
+exports[`manual - es5 should check arguments 3`] = `"First argument to finishDraft should be an object from createDraft."`;
+
+exports[`manual - es5 should support patches drafts 1`] = `
+Array [
+  Array [
+    Array [
+      Object {
+        "op": "replace",
+        "path": Array [
+          "a",
+        ],
+        "value": 2,
+      },
+      Object {
+        "op": "add",
+        "path": Array [
+          "b",
+        ],
+        "value": 3,
+      },
+    ],
+    Array [
+      Object {
+        "op": "replace",
+        "path": Array [
+          "a",
+        ],
+        "value": 1,
+      },
+      Object {
+        "op": "remove",
+        "path": Array [
+          "b",
+        ],
+      },
+    ],
+  ],
+]
+`;
+
+exports[`manual - proxy cannot modify after finish 1`] = `"Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":2}"`;
+
+exports[`manual - proxy should check arguments 1`] = `"First argument to createDraft should be a plain object, an array, or an immerable object."`;
+
+exports[`manual - proxy should check arguments 2`] = `"First argument to createDraft should be a plain object, an array, or an immerable object."`;
+
+exports[`manual - proxy should check arguments 3`] = `"First argument to finishDraft should be an object from createDraft."`;
+
+exports[`manual - proxy should support patches drafts 1`] = `
+Array [
+  Array [
+    Array [
+      Object {
+        "op": "replace",
+        "path": Array [
+          "a",
+        ],
+        "value": 2,
+      },
+      Object {
+        "op": "add",
+        "path": Array [
+          "b",
+        ],
+        "value": 3,
+      },
+    ],
+    Array [
+      Object {
+        "op": "replace",
+        "path": Array [
+          "a",
+        ],
+        "value": 1,
+      },
+      Object {
+        "op": "remove",
+        "path": Array [
+          "b",
+        ],
+      },
+    ],
+  ],
+]
+`;

--- a/__tests__/manual.js
+++ b/__tests__/manual.js
@@ -1,0 +1,148 @@
+"use strict"
+import {setUseProxies, createDraft, finishDraft, produce} from "../src/index"
+
+runTests("proxy", true)
+runTests("es5", false)
+
+function runTests(name, useProxies) {
+    describe("manual - " + name, () => {
+        setUseProxies(useProxies)
+
+        it("should check arguments", () => {
+            expect(() => createDraft(3)).toThrow(
+                "argument to createDraft should be a plain"
+            )
+            expect(() => createDraft(new Buffer([]))).toThrow(
+                "argument to createDraft should be a plain"
+            )
+            expect(() => finishDraft({})).toThrow(
+                "First argument to finishDraft should be "
+            )
+        })
+
+        it("should support manual drafts", () => {
+            const state = [{}, {}, {}]
+
+            const draft = createDraft(state)
+            draft.forEach((item, index) => {
+                item.index = index
+            })
+
+            const result = finishDraft(draft)
+
+            expect(result).not.toBe(state)
+            expect(result).toEqual([{index: 0}, {index: 1}, {index: 2}])
+            expect(state).toEqual([{}, {}, {}])
+        })
+
+        it("cannot modify after finish", () => {
+            const state = {a: 1}
+
+            const draft = createDraft(state)
+            draft.a = 2
+            expect(finishDraft(draft)).toEqual({a: 2})
+            expect(() => {
+                draft.a = 3
+            }).toThrow("Cannot use a proxy that has been revoked")
+        })
+
+        it("should support patches drafts", () => {
+            const state = {a: 1}
+
+            const draft = createDraft(state)
+            draft.a = 2
+            draft.b = 3
+
+            const patches = []
+            const result = finishDraft(draft, (p, ip) => {
+                patches.push(p, ip)
+            })
+
+            expect(result).not.toBe(state)
+            expect(result).toEqual({a: 2, b: 3})
+            expect(patches).toEqual([
+                [
+                    {
+                        op: "replace",
+                        path: ["a"],
+                        value: 2
+                    },
+                    {
+                        op: "add",
+                        path: ["b"],
+                        value: 3
+                    }
+                ],
+                [
+                    {
+                        op: "replace",
+                        path: ["a"],
+                        value: 1
+                    },
+                    {
+                        op: "remove",
+                        path: ["b"]
+                    }
+                ]
+            ])
+        })
+
+        it("should handle multiple create draft calls", () => {
+            const state = {a: 1}
+
+            const draft = createDraft(state)
+            draft.a = 2
+
+            const draft2 = createDraft(state)
+            draft2.b = 3
+
+            const result = finishDraft(draft)
+
+            expect(result).not.toBe(state)
+            expect(result).toEqual({a: 2})
+
+            draft2.a = 4
+            const result2 = finishDraft(draft2)
+            expect(result2).not.toBe(result)
+            expect(result2).toEqual({a: 4, b: 3})
+        })
+
+        it("combines with produce - 1", () => {
+            const state = {a: 1}
+
+            const draft = createDraft(state)
+            draft.a = 2
+            const res1 = produce(draft, d => {
+                d.b = 3
+            })
+            draft.b = 4
+            const res2 = finishDraft(draft)
+            expect(res1).toEqual({a: 2, b: 3})
+            expect(res2).toEqual({a: 2, b: 4})
+        })
+
+        it("combines with produce - 2", () => {
+            const state = {a: 1}
+
+            const res1 = produce(state, draft => {
+                draft.b = 3
+                const draft2 = createDraft(draft)
+                draft.c = 4
+                draft2.d = 5
+                const res2 = finishDraft(draft2)
+                expect(res2).toEqual({
+                    a: 1,
+                    b: 3,
+                    d: 5
+                })
+                draft.d = 2
+            })
+            expect(res1).toEqual({
+                a: 1,
+                b: 3,
+                c: 4,
+                d: 2
+            })
+        })
+    })
+}

--- a/__tests__/manual.js
+++ b/__tests__/manual.js
@@ -119,5 +119,18 @@ function runTests(name, useProxies) {
                 d: 2
             })
         })
+
+        it("should not finish drafts from produce", () => {
+            produce({x: 1}, draft => {
+                expect(() => finishDraft(draft)).toThrowErrorMatchingSnapshot()
+            })
+        })
+
+        it("should not finish twice", () => {
+            const draft = createDraft({a: 1})
+            draft.a++
+            finishDraft(draft)
+            expect(() => finishDraft(draft)).toThrowErrorMatchingSnapshot()
+        })
     })
 }

--- a/readme.md
+++ b/readme.md
@@ -337,7 +337,7 @@ Tip: Check this trick to [compress patches](https://medium.com/@david.b.edelstei
 
 ## Async producers
 
-It is allowed to return Promise objects from recipes. Or, in other words, to use `async / await`. This can be pretty useful for long running processes, that only produce the new object once the promise chain resolves. Note that `produce` itself (even in the curried form) itself will return a promise if the producer is async. Example:
+It is allowed to return Promise objects from recipes. Or, in other words, to use `async / await`. This can be pretty useful for long running processes, that only produce the new object once the promise chain resolves. Note that `produce` itself (even in the curried form) will return a promise if the producer is async. Example:
 
 ```javascript
 import produce from "immer"
@@ -347,8 +347,8 @@ const user = {
     todos: []
 }
 
-const loadedUser = await produce(users, async function(draft) {
-    user.todos = await window.fetch("http://host/" + draft.name).json()
+const loadedUser = await produce(user, async function(draft) {
+    user.todos = await (await window.fetch("http://host/" + draft.name)).json()
 })
 ```
 
@@ -359,7 +359,7 @@ _Warning: please note that the draft shouldn't be 'leaked' from the async proces
 `createDraft` and `finishDraft` are two low-level functions that are mostly useful for libraries that build abstractions on top of immer. It avoids the need to always create a function in order to work with drafts. Instead, one can create a draft, modify it, and at some time in the future finish the draft, in which case the next immutable state will be produced. We could for example rewrite our above example as:
 
 ```javascript
-import { createDraft, finishDraft } from "immer"
+import {createDraft, finishDraft} from "immer"
 
 const user = {
     name: "michel",
@@ -367,7 +367,7 @@ const user = {
 }
 
 const draft = createDraft(user)
-const draft.todos = await window.fetch("http://host/" + draft.name).json()
+draft.todos = await (await window.fetch("http://host/" + draft.name)).json()
 const loadedUser = finishDraft(draft)
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -711,6 +711,12 @@ Most important observation:
 -   Generating patches doesn't significantly slow immer down
 -   The ES5 fallback implementation is roughly twice as slow as the proxy implementation, in some cases worse.
 
+## Migration
+
+**Immer 1.\* -> 2.0**
+
+Make sure you don't return any promises as state, because `produce` will actually invoke the promise and wait until it settles.
+
 ## FAQ
 
 _(for those who skimmed the above instead of actually reading)_

--- a/src/es5.js
+++ b/src/es5.js
@@ -11,6 +11,8 @@ import {
 } from "./common"
 import {ImmerScope} from "./scope"
 
+// property descriptors are recycled to make sure we don't create a get and set closure per property,
+// but share them all instead
 const descriptors = {}
 
 export function willFinalize(scope, result, isReplaced) {

--- a/src/es5.js
+++ b/src/es5.js
@@ -28,7 +28,7 @@ export function willFinalize(scope, result, isReplaced) {
     }
 }
 
-export function createDraft(base, parent) {
+export function createProxy(base, parent) {
     const isArray = Array.isArray(base)
     const draft = clonePotentialDraft(base)
     each(draft, prop => {
@@ -70,7 +70,7 @@ function get(state, prop) {
     // Drafts are only created for proxyable values that exist in the base state.
     if (!state.finalizing && value === state.base[prop] && isDraftable(value)) {
         prepareCopy(state)
-        return (state.copy[prop] = createDraft(value, state))
+        return (state.copy[prop] = createProxy(value, state))
     }
     return value
 }

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -155,15 +155,18 @@ export function setUseProxies(useProxies: boolean): void
 export function applyPatches<S>(base: S, patches: Patch[]): S
 
 /**
- * Creates a mutable draft from an (immutable) object / array.
- * The draft can be modified until `finishDraft` is called
+ * Create an Immer draft from the given base state, which may be a draft itself.
+ * The draft can be modified until you finalize it with the `finishDraft` function.
  */
 export function createDraft<T>(base: T): Draft<T>
 
 /**
- * Given a draft that was created using `createDraft`,
- * finalizes the draft into a new immutable object.
- * Optionally a patch-listener can be provided to gather the patches that are needed to construct the object.
+ * Finalize an Immer draft from a `createDraft` call, returning the base state
+ * (if no changes were made) or a modified copy. The draft must *not* be
+ * mutated afterwards.
+ *
+ * Pass a function as the 2nd argument to generate Immer patches based on the
+ * changes that were made.
  */
 export function finishDraft<T>(base: Draft<T>, listener?: PatchListener): T
 

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -43,17 +43,15 @@ export interface Patch {
 
 export type PatchListener = (patches: Patch[], inversePatches: Patch[]) => void
 
-type IsVoidLike<T> = T extends void | undefined ? 1 : 0
-
 /** Converts `nothing` into `undefined` */
-type FromNothing<T> = Nothing extends T ? Exclude<T, Nothing> | undefined : T
+type FromNothing<T> = T extends Nothing ? undefined : T
 
 /** The inferred return type of `produce` */
-export type Produced<T, Return> = IsVoidLike<Return> extends 0
-    ? FromNothing<Return>
-    : IsVoidLike<Return> extends 1
-    ? T
-    : T | FromNothing<Exclude<Return, void>>
+export type Produced<Base, Return> = Return extends void
+    ? Base
+    : Return extends Promise<infer Result>
+    ? Promise<Result extends void ? Base : FromNothing<Result>>
+    : FromNothing<Return>
 
 type ImmutableTuple<T extends ReadonlyArray<any>> = {
     readonly [P in keyof T]: Immutable<T[P]>
@@ -168,7 +166,7 @@ export function createDraft<T>(base: T): Draft<T>
  * Pass a function as the 2nd argument to generate Immer patches based on the
  * changes that were made.
  */
-export function finishDraft<T>(base: Draft<T>, listener?: PatchListener): T
+export function finishDraft<T>(draft: T, listener?: PatchListener): Immutable<T>
 
 /** Get the underlying object that is represented by the given draft */
 export function original<T>(value: T): T | void

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -154,6 +154,19 @@ export function setUseProxies(useProxies: boolean): void
  */
 export function applyPatches<S>(base: S, patches: Patch[]): S
 
+/**
+ * Creates a mutable draft from an (immutable) object / array.
+ * The draft can be modified until `finishDraft` is called
+ */
+export function createDraft<T>(base: T): Draft<T>
+
+/**
+ * Given a draft that was created using `createDraft`,
+ * finalizes the draft into a new immutable object.
+ * Optionally a patch-listener can be provided to gather the patches that are needed to construct the object.
+ */
+export function finishDraft<T>(base: Draft<T>, listener?: PatchListener): T
+
 /** Get the underlying object that is represented by the given draft */
 export function original<T>(value: T): T | void
 

--- a/src/immer.js
+++ b/src/immer.js
@@ -91,11 +91,17 @@ export class Immer {
         const scope = ImmerScope.enter()
         const proxy = this.createProxy(base)
         scope.leave()
+        proxy[DRAFT_STATE].customDraft = true
         return proxy
     }
     finishDraft(draft, patchListener) {
         if (!isDraft(draft)) throw new Error("First argument to finishDraft should be an object from createDraft.") // prettier-ignore
-        const {scope} = draft[DRAFT_STATE]
+        const state = draft[DRAFT_STATE]
+        if (!state.customDraft) throw new Error("The draft provided was not created using `createDraft`") // prettier-ignore
+        if (state.finalized) throw new Error("The draft provided was has already been finished") // prettier-ignore
+        // TODO: check if created with createDraft
+        // TODO: check if not finsihed twice
+        const {scope} = state
         scope.usePatches(patchListener)
         return this.processResult(undefined, scope)
     }

--- a/src/immer.js
+++ b/src/immer.js
@@ -86,6 +86,19 @@ export class Immer {
             return result !== NOTHING ? result : undefined
         }
     }
+    createPublicDraft(value) {
+        if (!isDraftable(value)) throw new Error("First argument to createDraft should be a plain-, or immerable object, or array.") // prettier-ignore
+        const scope = ImmerScope.enter()
+        const draft = this.createDraft(value)
+        scope.leave()
+        return draft
+    }
+    finishPublicDraft(draft, patchListener) {
+        if (!isDraft(draft)) throw new Error("First argument to finishDraft should be an object created with createDraft.") // prettier-ignore
+        const {scope} = draft[DRAFT_STATE]
+        scope.usePatches(patchListener)
+        return this.processResult(undefined, scope)
+    }
     setAutoFreeze(value) {
         this.autoFreeze = value
     }

--- a/src/immer.js
+++ b/src/immer.js
@@ -56,10 +56,10 @@ export class Immer {
         // Only plain objects, arrays, and "immerable classes" are drafted.
         if (isDraftable(base)) {
             const scope = ImmerScope.enter()
-            const baseDraft = this.createDraft(base)
+            const proxy = this.createProxy(base)
             let hasError = true
             try {
-                result = recipe.call(baseDraft, baseDraft)
+                result = recipe.call(proxy, proxy)
                 hasError = false
             } finally {
                 // finally instead of catch + rethrow better preserves original stack
@@ -86,15 +86,15 @@ export class Immer {
             return result !== NOTHING ? result : undefined
         }
     }
-    createPublicDraft(value) {
-        if (!isDraftable(value)) throw new Error("First argument to createDraft should be a plain-, or immerable object, or array.") // prettier-ignore
+    createDraft(base) {
+        if (!isDraftable(base)) throw new Error("First argument to createDraft should be a plain object, an array, or an immerable object.") // prettier-ignore
         const scope = ImmerScope.enter()
-        const draft = this.createDraft(value)
+        const proxy = this.createProxy(base)
         scope.leave()
-        return draft
+        return proxy
     }
-    finishPublicDraft(draft, patchListener) {
-        if (!isDraft(draft)) throw new Error("First argument to finishDraft should be an object created with createDraft.") // prettier-ignore
+    finishDraft(draft, patchListener) {
+        if (!isDraft(draft)) throw new Error("First argument to finishDraft should be an object from createDraft.") // prettier-ignore
         const {scope} = draft[DRAFT_STATE]
         scope.usePatches(patchListener)
         return this.processResult(undefined, scope)

--- a/src/immer.js
+++ b/src/immer.js
@@ -57,13 +57,15 @@ export class Immer {
         if (isDraftable(base)) {
             const scope = ImmerScope.enter()
             const baseDraft = this.createDraft(base)
+            let hasError = true
             try {
                 result = recipe.call(baseDraft, baseDraft)
-            } catch (error) {
-                scope.revoke()
-                throw error
+                hasError = false
+            } finally {
+                // finally instead of catch + rethrow better preserves original stack
+                if (hasError) scope.revoke()
+                else scope.leave()
             }
-            scope.leave()
             if (result instanceof Promise) {
                 return result.then(
                     result => {

--- a/src/immer.js.flow
+++ b/src/immer.js.flow
@@ -90,3 +90,16 @@ declare export function applyPatches<S>(state: S, patches: Patch[]): S
 declare export function original<S>(value: S): ?S
 
 declare export function isDraft(value: any): boolean
+
+/**
+ * Creates a mutable draft from an (immutable) object / array. 
+ * The draft can be modified until `finishDraft` is called
+ */
+declare export function createDraft<T>(base: T): T
+
+/**
+ * Given a draft that was created using `createDraft`, 
+ * finalizes the draft into a new immutable object.
+ * Optionally a patch-listener can be provided to gather the patches that are needed to construct the object.
+ */
+declare export function finishDraft<T>(base: T, listener?: PatchListener): T

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,10 @@ export const setUseProxies = immer.setUseProxies.bind(immer)
  */
 export const applyPatches = immer.applyPatches.bind(immer)
 
+export const createDraft = immer.createPublicDraft.bind(immer)
+
+export const finishDraft = immer.finishPublicDraft.bind(immer)
+
 export {
     original,
     isDraft,

--- a/src/index.js
+++ b/src/index.js
@@ -46,9 +46,21 @@ export const setUseProxies = immer.setUseProxies.bind(immer)
  */
 export const applyPatches = immer.applyPatches.bind(immer)
 
-export const createDraft = immer.createPublicDraft.bind(immer)
+/**
+ * Create an Immer draft from the given base state, which may be a draft itself.
+ * The draft can be modified until you finalize it with the `finishDraft` function.
+ */
+export const createDraft = immer.createDraft.bind(immer)
 
-export const finishDraft = immer.finishPublicDraft.bind(immer)
+/**
+ * Finalize an Immer draft from a `createDraft` call, returning the base state
+ * (if no changes were made) or a modified copy. The draft must *not* be
+ * mutated afterwards.
+ *
+ * Pass a function as the 2nd argument to generate Immer patches based on the
+ * changes that were made.
+ */
+export const finishDraft = immer.finishDraft.bind(immer)
 
 export {
     original,

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -14,7 +14,7 @@ import {ImmerScope} from "./scope"
 // Do nothing before being finalized.
 export function willFinalize() {}
 
-export function createDraft(base, parent) {
+export function createProxy(base, parent) {
     const scope = parent ? parent.scope : ImmerScope.current
     const state = {
         // Track which produce call this is associated with.
@@ -119,7 +119,7 @@ function get(state, prop) {
         drafts = state.copy
     }
 
-    return (drafts[prop] = createDraft(value, state))
+    return (drafts[prop] = createProxy(value, state))
 }
 
 function set(state, prop, value) {

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -1,6 +1,4 @@
 "use strict"
-// @ts-check
-
 import {
     assign,
     each,
@@ -11,18 +9,16 @@ import {
     shallowCopy,
     DRAFT_STATE
 } from "./common"
-
-// For nested produce calls:
-export const scopes = []
-export const currentScope = () => scopes[scopes.length - 1]
+import {ImmerScope} from "./scope"
 
 // Do nothing before being finalized.
 export function willFinalize() {}
 
 export function createDraft(base, parent) {
+    const scope = parent ? parent.scope : ImmerScope.current
     const state = {
         // Track which produce call this is associated with.
-        scope: parent ? parent.scope : currentScope(),
+        scope,
         // True for both shallow and deep changes.
         modified: false,
         // Used during finalization.
@@ -50,7 +46,7 @@ export function createDraft(base, parent) {
     state.draft = proxy
     state.revoke = revoke
 
-    state.scope.push(state)
+    scope.drafts.push(proxy)
     return proxy
 }
 

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -40,7 +40,9 @@ export function createDraft(base, parent) {
     }
 
     const {revoke, proxy} = Array.isArray(base)
-        ? Proxy.revocable([state], arrayTraps)
+        ? // [state] is used for arrays, to make sure the proxy is array-ish and not violate invariants,
+          // although state itself is an object
+          Proxy.revocable([state], arrayTraps)
         : Proxy.revocable(state, objectTraps)
 
     state.draft = proxy
@@ -92,6 +94,7 @@ arrayTraps.set = function(state, prop, value) {
     return objectTraps.set.call(this, state[0], prop, value)
 }
 
+// returns the object we should be reading the current value from, which is base, until some change has been made
 function source(state) {
     return state.copy || state.base
 }

--- a/src/scope.js
+++ b/src/scope.js
@@ -1,0 +1,38 @@
+import {DRAFT_STATE} from "./common"
+
+/** Each scope represents a `produce` call. */
+export class ImmerScope {
+    constructor(parent) {
+        this.drafts = []
+        this.parent = parent
+
+        // To avoid prototype lookups:
+        this.patches = null
+    }
+    usePatches(patchListener) {
+        if (patchListener) {
+            this.patches = []
+            this.inversePatches = []
+            this.patchListener = patchListener
+        }
+    }
+    revoke() {
+        this.leave()
+        this.drafts.forEach(revoke)
+        this.drafts = null // Make draft-related methods throw.
+    }
+    leave() {
+        if (this === ImmerScope.current) {
+            ImmerScope.current = this.parent
+        }
+    }
+}
+
+ImmerScope.current = null
+ImmerScope.enter = function() {
+    return (this.current = new ImmerScope(this.current))
+}
+
+function revoke(draft) {
+    draft[DRAFT_STATE].revoke()
+}

--- a/src/scope.js
+++ b/src/scope.js
@@ -6,6 +6,10 @@ export class ImmerScope {
         this.drafts = []
         this.parent = parent
 
+        // Whenever the modified draft contains a draft from another scope, we
+        // need to prevent auto-freezing so the unowned draft can be finalized.
+        this.canAutoFreeze = true
+
         // To avoid prototype lookups:
         this.patches = null
     }


### PR DESCRIPTION
Localized branch of #305, implements #302 

Remaining work: 

* [x] docs
* [x] `createDraft`  / `finishDraft` api
* [x] typings `create`/`finish` `Draft`
* [x] typings async produce
