### PR TITLE
fix: share internal symbols between immer installations

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -5,11 +5,11 @@ export const NOTHING =
 
 export const DRAFTABLE =
     typeof Symbol !== "undefined"
-        ? Symbol("immer-draftable")
+        ? Symbol.for("immer-draftable")
         : "__$immer_draftable"
 
 export const DRAFT_STATE =
-    typeof Symbol !== "undefined" ? Symbol("immer-state") : "__$immer_state"
+    typeof Symbol !== "undefined" ? Symbol.for("immer-state") : "__$immer_state"
 
 export function isDraft(value) {
     return !!value && !!value[DRAFT_STATE]


### PR DESCRIPTION
This uses `Symbol.for` when creating the `DRAFTABLE` and `DRAFT_STATE` symbols, so that separate installations of Immer can work together.

**Note:** The `nothing` symbol is still not portable across installations, since it never escapes any producer that returns it. The only reason this could be an issue is if an Immer-using library transparently wraps a user's function and asks them to install their own copy of Immer if they want to return `nothing` (in that case, the library should instead re-export `nothing` for its users).

This repro shows this PR working as expected:
https://github.com/aleclarson/repro/tree/portable-immer

Fixes #322