### PR TITLE
fix(ts): --target=es5 compatibility

### DIFF
--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -238,3 +238,11 @@ export interface ImmerState<T = any> {
     copy: T
     assigned: {[prop: string]: boolean; [index: number]: boolean}
 }
+
+// Backward compatibility with --target es5
+declare global {
+    interface Set<T> {}
+    interface Map<K, V> {}
+    interface WeakSet<T> {}
+    interface WeakMap<K extends object, V> {}
+}


### PR DESCRIPTION
I noticed that `@types/lodash` uses this declaration for ES5 compatibility.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6a5529e838d9386fb6567296e84d945e25805281/types/lodash/index.d.ts#L37-L47

Fixes #321