### PR TITLE
I think RN 0.59 no longer needs Proxy polyfill on Android

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -505,7 +505,7 @@ Immer automatically freezes any state trees that are modified using `produce`. T
 
 ## Immer on older JavaScript environments?
 
-By default `produce` tries to use proxies for optimal performance. However, on older JavaScript engines `Proxy` is not available. For example, when running Microsoft Internet Explorer or React Native on Android. In such cases, Immer will fallback to an ES5 compatible implementation which works identical, but is a bit slower.
+By default `produce` tries to use proxies for optimal performance. However, on older JavaScript engines `Proxy` is not available. For example, when running Microsoft Internet Explorer or React Native (< v0.59) on Android. In such cases, Immer will fallback to an ES5 compatible implementation which works identical, but is a bit slower.
 
 ## Importing immer
 


### PR DESCRIPTION
With React Native 0.59 release - they upgraded the Android JSC so I think this polyfill is no longer needed - https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md


I might be wrong here, can someone else confirm please?